### PR TITLE
rung0-08: GPU verification fixes (typedefs, hanging NCCL test, launch-failure coverage)

### DIFF
--- a/crates/atoma-kernels/kernels/cache_manager.cu
+++ b/crates/atoma-kernels/kernels/cache_manager.cu
@@ -3,11 +3,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <map>
 #include <vector>
-
-typedef unsigned short uint16_t;
-typedef unsigned long uint32_t;
 
 namespace vllm {
 

--- a/crates/atoma-kernels/tests/launch_failure_probe.rs
+++ b/crates/atoma-kernels/tests/launch_failure_probe.rs
@@ -1,0 +1,64 @@
+//! Manual probe for acceptance criterion 5 of #156: a launch that the driver actually rejects must
+//! reach Rust as `KernelError::LaunchFailed` carrying the driver's message, and the process must
+//! survive to observe it.
+//!
+//! No ordinary test reaches this path, because every other test launches a well-formed grid. This
+//! one oversubscribes `gridDim.y`: `copy_blocks_cache` launches `dim3 grid(1, num_pairs)`, and the
+//! hardware caps `gridDim.y` at 65535, so a mapping with more pairs than that is rejected by the
+//! driver at launch time rather than by any check of ours.
+
+#![cfg(feature = "cuda")]
+
+use candle_core::{DType, Device, Tensor};
+
+const NUM_BLOCKS: usize = 4;
+const BLOCK_SIZE: usize = 64;
+const NUM_HEADS: usize = 2;
+const HEAD_SIZE: usize = 8;
+
+/// One past the hardware limit on `gridDim.y`.
+const PAIRS_OVER_GRID_LIMIT: usize = 65_536;
+
+#[test]
+fn a_launch_the_driver_rejects_surfaces_as_an_error_and_the_process_survives() {
+    let device = Device::new_cuda(0).unwrap();
+
+    let mut key_cache = Tensor::zeros(
+        &[NUM_BLOCKS, BLOCK_SIZE, NUM_HEADS, HEAD_SIZE],
+        DType::F16,
+        &device,
+    )
+    .unwrap();
+    let mut value_cache = Tensor::zeros(
+        &[NUM_BLOCKS, BLOCK_SIZE, NUM_HEADS, HEAD_SIZE],
+        DType::F16,
+        &device,
+    )
+    .unwrap();
+
+    // Every pair copies block 0 onto itself, so the mapping is in bounds. The only thing wrong with
+    // this launch is the size of the grid it asks for.
+    let block_mapping = Tensor::zeros(&[PAIRS_OVER_GRID_LIMIT, 2], DType::I64, &device).unwrap();
+
+    let error = atoma_kernels::copy_blocks(&[&mut key_cache], &[&mut value_cache], block_mapping)
+        .expect_err("a grid of 65536 in y must be rejected by the driver");
+
+    let rendered = error.to_string();
+    println!("observed error: {rendered}");
+
+    assert!(
+        rendered.contains("copy_blocks_cache"),
+        "the error must name the FFI entry point that failed, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("failed with CUDA error"),
+        "the error must carry the driver's code, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("invalid configuration argument"),
+        "the error must carry the driver's own message, got: {rendered}"
+    );
+
+    // Reaching this line at all is the point: the process was not terminated by the failing launch.
+    println!("process survived the failing launch");
+}

--- a/crates/backends/vllm/src/tests/llama_nccl.rs
+++ b/crates/backends/vllm/src/tests/llama_nccl.rs
@@ -9,6 +9,7 @@ use std::{path::PathBuf, time::Instant};
 use tracing::info;
 
 #[tokio::test]
+#[ignore = "requires 2 GPUs (test_config_nccl.toml sets device_ids = [0, 1]); hangs indefinitely on a single-GPU host. Run with `cargo test --features cuda,nccl -- --ignored`"]
 async fn test_llama_nccl_model() {
     crate::tests::init_tracing();
 


### PR DESCRIPTION
Found while running the rung0-08 GPU verification of #162 on an A100-SXM4-40GB (driver 580.105.08, CUDA 12.8, SM80). The #162 code had never been compiled; this is the first run of it against a compiler and a GPU.

## `cache_manager.cu`: use `<cstdint>`

The file defined `typedef unsigned long uint32_t`, which is 8 bytes on LP64. Rust declares `dtype: u32` as the 10th argument of `reshape_and_cache_flash_cache`, so under the SysV ABI it is passed on the stack rather than in a register. The callee read 8 bytes from that slot and picked up 4 bytes of uninitialized stack above the value Rust wrote, so `dtype` matched neither 0 nor 1 and the launcher returned `cudaErrorInvalidValue`.

This was not latent. It failed `test_reshape_and_cache_flash_f16` and `test_reshape_and_cache_flash_bf16` with `CUDA error 1: invalid argument` — the only two failures in the first CUDA run. #162 left the typedefs in place on the reasoning that register zero-extension made them harmless; that reasoning does not apply to a stack-passed argument.

With `<cstdint>`, `cache_manager_tests` is 19/19.

## Ignore the llama-nccl e2e test

`test_llama_nccl_model` drives `LlmService` through `test_config_nccl.toml`, which sets `device_ids = [0, 1]`. On a single-GPU host it does not fail — it spins at 100% CPU with the GPU idle and never returns, so `cargo test --features cuda,nccl` hangs indefinitely instead of reporting a result.

Its counterpart in `crates/models/src/llama_nccl.rs` is already ignored, but for a different reason (gated weights). This one uses TinyLlama, so the blocker is GPU count, not `HF_API_KEY`.

## Cover the failing-launch path

`launch_error_surfacing.rs` reads the sources, so it proves the code is shaped to record and return a status — not that a real driver rejection surfaces as `KernelError::LaunchFailed` with the process intact. Nothing observed that at runtime.

`copy_blocks_cache` launches `dim3 grid(1, num_pairs)` and the hardware caps `gridDim.y` at 65535, so a mapping with 65536 pairs is rejected by the driver at launch. That needs one GPU and no special setup, so the check that previously had to be done by hand now just runs.

Observed: `copy_blocks_cache failed with CUDA error 9: invalid configuration argument`, process survived.

## Verification

Both suites green on the A100 at `b488cfa` plus these three commits:

- `--features cuda`: 137 passed, 0 failed, 3 ignored
- `--features cuda,nccl`: 142 passed, 0 failed, 5 ignored
- `cargo clippy --workspace --all-targets --features cuda,nccl -- -D warnings`: clean
- `cargo +nightly fmt --check`: clean

The four guards from the #157 runbook were checked by break-then-fix. Three go red when reverted, as intended. The fourth — the LSE buffer at `flash_attention.rs:232` — is not covered by any test; details in the issue thread.