### PR TITLE
docs: record tensor-path and kernel-policy decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,83 @@
+# atoma-infer
+
+Rust-native LLM inference engine: CUDA kernels bound via cudarc, an OpenAI-compatible API, and a
+scheduler/KV core designed for frontier MoE serving.
+
+## Language
+
+### Planning
+
+**Rung**:
+One level of the capability ladder (un-brick → engine core → performance core → MoE → MLA →
+launch completion). Work lands on its rung; each rung exits on a measured gate.
+
+**Launch gate**:
+The measured bar for launch: goodput within 10% of the better of vLLM/SGLang on DeepSeek-class
+serving, plus at least two outright headline wins.
+
+**Spike**:
+A short, time-boxed build that answers a design question with evidence. Distinct from a
+prototype ticket only in that its outcome feeds a spec rather than deciding between substrates.
+
+### Tensors and substrates
+
+**Tensor path**:
+The decode hot path built on `atoma-runtime::Tensor` — our tensor type over cudarc-owned device
+buffers. All hot-path math lives here.
+_Avoid_: "candle path" for anything performance-critical
+
+**Cold path**:
+The non-latency-critical work candle still owns: weight loading and host-side glue. Retires
+family-by-family as model definitions move to the tensor path.
+
+### CUDA graphs
+
+**FullDecodeOnly step**:
+A decode step for a batch in which every sequence generates exactly one token (or 1+k under
+speculation) — the uniform shape that a full-graph capture covers.
+
+**Uniform decode**:
+The dispatch predicate for FullDecodeOnly: every request in the batch has the same query length
+(1, or 1+k with speculation).
+
+**Bucket ladder**:
+The fixed list of batch sizes at which decode graphs are captured (e.g. 1/8/32/64).
+
+**Pad-to-bucket**:
+Padding a live batch up to the nearest captured bucket size and replaying that graph, rather
+than falling back to eager execution.
+
+**Replay**:
+Launching a captured graph for a new step: persistent input buffers are rewritten in place,
+then the graph executes with no per-kernel launch overhead.
+
+**Replay soak**:
+A sustained run of consecutive replays (~1000) asserting no graph invalidation and no memory
+growth.
+
+**Segmented capture**:
+Capturing the static kernel segments between eager break points (attention/MoE boundaries) as
+separate graphs, so mixed and prefill batches also benefit. The native equivalent of vLLM's
+piecewise mode, without torch.compile.
+
+**Capture-legal**:
+Property of a kernel or op sequence that can run inside CUDA stream capture: no synchronous
+allocs, no stream syncs, no legacy-stream use.
+
+### Kernel policy
+
+**Bindings-first**:
+The rule that external kernels are consumed as prebuilt artifacts or libraries with Rust host
+logic — never vendored as sources. See ADR 0001.
+
+**Artifact pin**:
+The pinned prebuilt kernel artifact (cubin/library version) a release binds against; host-side
+launch logic is re-verified when the pin moves.
+
+**Plan/run split**:
+The graph-compatible attention contract: `plan` computes scheduling metadata on the host outside
+capture; `run` executes inside capture reading only persistent buffers.
+
+**In-house kernel**:
+A `.cu` file we author and own in-repo (paged-KV cache ops, fused elementwise). The deliberate
+exception to bindings-first: no upstream to track.

--- a/docs/adr/0001-bindings-first-kernel-policy.md
+++ b/docs/adr/0001-bindings-first-kernel-policy.md
@@ -1,0 +1,19 @@
+# Bindings-first kernel policy
+
+External CUDA kernels are never vendored as sources. They are consumed as prebuilt artifacts or
+libraries — FlashInfer cubins loaded via cudarc for attention, cuBLASLt for GEMM, NCCL for
+comms — with the host-side plan/run logic implemented in Rust. Small in-house kernels
+(paged-KV cache ops, fused elementwise) stay in-repo as `.cu`: they have no upstream team to
+diverge from.
+
+The repo previously vendored flash-attention 2 forward kernels (66 translation units) plus the
+cutlass submodule to build them. Maintaining patched copies of external kernels in parallel to
+their upstream teams does not scale to the kernel surface this engine needs (FA3-class SM90,
+MLA, SM100). The vendored FA2 kernels are frozen; the change that lands FlashInfer-bound SM90
+attention deletes them and the cutlass submodule in the same PR, gated on golden-test parity.
+
+Accepted cost: reimplementing each artifact's host-side launch/plan logic in Rust, re-verified
+per artifact pin. The alternative — vendoring FA3 sources + cutlass 3.x + patches — was the
+same maintenance burden this policy exists to end.
+
+Decision record: AtomaAI/atoma-infer#169 (2026-08-05).

--- a/docs/adr/0002-tensor-path-hot-path.md
+++ b/docs/adr/0002-tensor-path-hot-path.md
@@ -1,0 +1,16 @@
+# The decode hot path runs on atoma-runtime tensors, not candle
+
+The decode hot path (model forward, attention, sampling inputs) is built on
+`atoma-runtime::Tensor` — our own tensor type over cudarc-owned device buffers. candle is
+cold-path only: weight loading and host-side glue, retiring family-by-family as model
+definitions move to the tensor path.
+
+Why not capture CUDA graphs over candle: production graph support here means decode-step graphs
+per batch-size bucket *and* segmented capture (eager break points at attention/MoE boundaries).
+Segmented capture needs deterministic allocator behavior between captured segments; over an
+allocator we don't own, that is the hardest version of the problem — built on a substrate that
+was already scheduled for retirement. Owning the buffers makes stable addresses, capture-pool
+management, and replay patching straightforward instead of adversarial.
+
+Decision record: AtomaAI/atoma-infer#168 (2026-08-05), amending the earlier
+prototype-first plan (capture-over-candle, AtomaAI/atoma-infer#143).


### PR DESCRIPTION
Adds the first two ADRs and a repo glossary.

- `docs/adr/0001-bindings-first-kernel-policy.md` — external kernels arrive as prebuilt artifacts (FlashInfer cubins via cudarc, cuBLASLt, NCCL) with Rust-side plan/run logic; in-house `.cu` stays; FA2 sources + cutlass submodule are deleted at the rung-2 FlashInfer SM90 swap. Canonical decision: #169.
- `docs/adr/0002-tensor-path-hot-path.md` — the decode hot path runs on `atoma-runtime::Tensor`; candle is cold-path only (weight loading, host glue). Canonical decision: #168.
- `CONTEXT.md` — glossary for the terms these decisions pinned (tensor path, cold path, bucket ladder, pad-to-bucket, uniform decode, segmented capture, capture-legal, bindings-first, artifact pin, plan/run split).

No code changes.